### PR TITLE
Fix README command examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,16 +71,9 @@ The following commands are available for managing Git repositories:
   Switches all repositories to the `main` branch if it exists; otherwise, switches to `master`.
 
   ```bash
-  python flamapy_dev.py git switch_main_or_master
+  python flamapy_dev.py git switch_main
   ```
 
-- **Pull Latest Changes**
-
-  Pulls the latest changes from all repositories.
-
-  ```bash
-  python flamapy_dev.py git pull
-  ```
 
 - **Delete Repositories**
 


### PR DESCRIPTION
## Summary
- update README to show `switch_main` usage and remove undocumented `git pull` example

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686a9140092483229d3fede464acfa1e