### PR TITLE
Improve develop switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ The following commands are available for managing Git repositories:
 - **Switch to Develop Branch**
 
   Switches all repositories to the `develop` branch if it exists.
+  If the branch only exists on the remote, it will be created locally first.
 
   ```bash
   python flamapy_dev.py git switch_develop

--- a/commands/repositories.py
+++ b/commands/repositories.py
@@ -38,6 +38,9 @@ def switch_develop(ctx):
             click.echo(f"Switching {repo_name} to branch develop...")
             if subprocess.run(["git", "show-ref", "--verify", "--quiet", "refs/heads/develop"], cwd=repo_dir).returncode == 0:
                 subprocess.run(["git", "switch", "develop"], cwd=repo_dir, check=True)
+            elif subprocess.run(["git", "ls-remote", "--exit-code", "--heads", "origin", "develop"], cwd=repo_dir).returncode == 0:
+                subprocess.run(["git", "fetch", "origin"], cwd=repo_dir, check=True)
+                subprocess.run(["git", "switch", "-c", "develop", "origin/develop"], cwd=repo_dir, check=True)
             else:
                 click.echo("Branch 'develop' does not exist.")
         else:

--- a/tests/test_repositories.py
+++ b/tests/test_repositories.py
@@ -69,3 +69,51 @@ def test_switch_main_or_master_uses_master():
     assert result.exit_code == 0
     switch_calls = [call.args[0] for call in run_mock.call_args_list if call.args and call.args[0][0:2] == ['git', 'switch']]
     assert switch_calls == [['git', 'switch', 'master']]
+
+
+def test_switch_develop_creates_local_from_remote():
+    runner = CliRunner()
+    repos = {'repo1': 'url1'}
+    obj = {'REPOS': repos, 'PARENT_DIR': '/tmp'}
+
+    def side_effect(args, cwd=None, check=False, **kwargs):
+        if args[0:3] == ['git', 'show-ref', '--verify']:
+            return DummyProcess(1)
+        elif args[0:3] == ['git', 'ls-remote', '--exit-code']:
+            return DummyProcess(0)
+        elif args[0:2] == ['git', 'switch']:
+            return DummyProcess(0)
+        elif args[0:2] == ['git', 'fetch']:
+            return DummyProcess(0)
+        return DummyProcess(0)
+
+    with patch('commands.repositories.os.path.isdir', return_value=True), \
+         patch('commands.repositories.subprocess.run', side_effect=side_effect) as run_mock:
+        result = runner.invoke(repositories.switch_develop, obj=obj)
+
+    assert result.exit_code == 0
+    switch_calls = [call.args[0] for call in run_mock.call_args_list if call.args and call.args[0][0:2] == ['git', 'switch']]
+    assert switch_calls == [['git', 'switch', '-c', 'develop', 'origin/develop']]
+
+
+def test_switch_develop_branch_missing_everywhere():
+    runner = CliRunner()
+    repos = {'repo1': 'url1'}
+    obj = {'REPOS': repos, 'PARENT_DIR': '/tmp'}
+
+    def side_effect(args, cwd=None, check=False, **kwargs):
+        if args[0:3] == ['git', 'show-ref', '--verify']:
+            return DummyProcess(1)
+        elif args[0:3] == ['git', 'ls-remote', '--exit-code']:
+            return DummyProcess(1)
+        elif args[0:2] == ['git', 'switch']:
+            return DummyProcess(0)
+        return DummyProcess(0)
+
+    with patch('commands.repositories.os.path.isdir', return_value=True), \
+         patch('commands.repositories.subprocess.run', side_effect=side_effect) as run_mock:
+        result = runner.invoke(repositories.switch_develop, obj=obj)
+
+    assert result.exit_code == 0
+    switch_calls = [call.args[0] for call in run_mock.call_args_list if call.args and call.args[0][0:2] == ['git', 'switch']]
+    assert switch_calls == []


### PR DESCRIPTION
## Summary
- create local develop branch from remote if missing
- document this in the README
- expand tests for switching to develop branch

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870e6d54b1483228e7c00d4b29e45a1