### PR TITLE
Add make commands and dev requirements

### DIFF
--- a/commands/__init__.py
+++ b/commands/__init__.py
@@ -1,7 +1,9 @@
 from .packages import pip
 from .repositories import git
 from .versions import version
+from .make import make
 
-__all__ = ['pip', 
+__all__ = ['pip',
            'git',
-           'version']
+           'version',
+           'make']

--- a/commands/make.py
+++ b/commands/make.py
@@ -1,0 +1,44 @@
+import click
+import subprocess
+import os
+
+@click.group()
+@click.pass_context
+def make(ctx):
+    """Run make targets on all repositories."""
+    ctx.ensure_object(dict)
+    ctx.obj['PARENT_DIR'] = ctx.obj.get('PARENT_DIR', '')
+    ctx.obj['REPOS'] = ctx.obj.get('REPOS', {})
+
+
+def _run_make(ctx, target: str):
+    parent_dir = ctx.obj['PARENT_DIR']
+    repos = ctx.obj['REPOS']
+    for repo_name in repos.keys():
+        repo_dir = os.path.join(parent_dir, repo_name)
+        if os.path.isdir(repo_dir):
+            click.echo(f"Running 'make {target}' in {repo_dir}")
+            subprocess.run(["make", target], cwd=repo_dir, check=True)
+        else:
+            click.echo(f"{repo_dir} does not exist.")
+
+
+@make.command()
+@click.pass_context
+def lint(ctx):
+    """Execute 'make lint' in all repositories."""
+    _run_make(ctx, "lint")
+
+
+@make.command(name="test")
+@click.pass_context
+def test_cmd(ctx):
+    """Execute 'make test' in all repositories."""
+    _run_make(ctx, "test")
+
+
+@make.command()
+@click.pass_context
+def mypy(ctx):
+    """Execute 'make mypy' in all repositories."""
+    _run_make(ctx, "mypy")

--- a/flamapy_dev.py
+++ b/flamapy_dev.py
@@ -1,5 +1,5 @@
 import click
-from commands import git, pip, version
+from commands import git, pip, version, make
 import os
 
 # Define the repositories and their URLs
@@ -53,6 +53,7 @@ def cli(ctx, parent_dir):
 cli.add_command(git)
 cli.add_command(pip)
 cli.add_command(version)
+cli.add_command(make)
 
 if __name__ == "__main__":
     cli()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+pytest
+flake8
+mypy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
 click
 bump-my-version==1.2.0
+pytest
+flake8
+mypy

--- a/tests/test_make.py
+++ b/tests/test_make.py
@@ -1,0 +1,47 @@
+from click.testing import CliRunner
+from unittest.mock import patch
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import importlib
+
+make_cmd = importlib.import_module('commands.make')
+
+
+def test_make_lint_runs_in_repo():
+    runner = CliRunner()
+    repos = {'repo1': 'url1'}
+    obj = {'REPOS': repos, 'PARENT_DIR': '/tmp'}
+    with patch('commands.make.os.path.isdir', return_value=True), \
+         patch('commands.make.subprocess.run') as run_mock:
+        result = runner.invoke(make_cmd.lint, obj=obj)
+
+    assert result.exit_code == 0
+    run_mock.assert_called_with(['make', 'lint'], cwd='/tmp/repo1', check=True)
+
+
+def test_make_test_runs_in_repo():
+    runner = CliRunner()
+    repos = {'repo1': 'url1'}
+    obj = {'REPOS': repos, 'PARENT_DIR': '/tmp'}
+    with patch('commands.make.os.path.isdir', return_value=True), \
+         patch('commands.make.subprocess.run') as run_mock:
+        result = runner.invoke(make_cmd.test_cmd, obj=obj)
+
+    assert result.exit_code == 0
+    run_mock.assert_called_with(['make', 'test'], cwd='/tmp/repo1', check=True)
+
+
+def test_make_mypy_missing_repo():
+    runner = CliRunner()
+    repos = {'repo1': 'url1'}
+    obj = {'REPOS': repos, 'PARENT_DIR': '/tmp'}
+    with patch('commands.make.os.path.isdir', return_value=False) as isdir_mock, \
+         patch('commands.make.subprocess.run') as run_mock:
+        result = runner.invoke(make_cmd.mypy, obj=obj)
+
+    assert result.exit_code == 0
+    run_mock.assert_not_called()
+


### PR DESCRIPTION
## Summary
- add new `make` command group to run `make lint`, `make test` and `make mypy` in all repositories
- expose new group in `commands.__init__` and register it in `flamapy_dev.py`
- include development dependencies and create `requirements-dev.txt`
- provide tests for the new make commands

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875110e804c8322b20eb0798ec17db5