### PR TITLE
Improve CLI usability and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ cd <repository_directory>
 
 ### Git Commands
 
-The following commands are available for managing Git repositories:
+The following commands are available for managing Git repositories.
+Use `--parent-dir PATH` to specify where the repositories are located (defaults to `..`):
 
 - **Clone Repositories**
 
@@ -72,7 +73,7 @@ The following commands are available for managing Git repositories:
   Switches all repositories to the `main` branch if it exists; otherwise, switches to `master`.
 
   ```bash
-  python flamapy_dev.py git switch_main
+  python flamapy_dev.py git switch-main
   ```
 
 

--- a/commands/repositories.py
+++ b/commands/repositories.py
@@ -46,9 +46,9 @@ def switch_develop(ctx):
         else:
             click.echo(f"{repo_name} does not exist.")
 
-@click.command(name="switch_main_or_master")
+@click.command(name="switch-main")
 @click.pass_context
-def switch_main_or_master(ctx):
+def switch_main(ctx):
     """Switch all repositories to the main branch if it exists, otherwise to master."""
     repos = ctx.obj['REPOS']
     parent_dir = ctx.obj['PARENT_DIR']
@@ -111,7 +111,7 @@ def delete(ctx):
 
 git.add_command(clone)
 git.add_command(switch_develop)
-git.add_command(switch_main_or_master)
+git.add_command(switch_main)
 git.add_command(pull)
 git.add_command(delete)
 git.add_command(status)

--- a/commands/versions.py
+++ b/commands/versions.py
@@ -58,23 +58,11 @@ def bump_with_bump_my_version(repo: Path, files: list, new_version: str):
 
 @click.group()
 @click.pass_context
-@click.argument('parent_dir',
-                default=os.curdir,
-                type=click.Path(exists=True, file_okay=False, dir_okay=True, writable=True),
-                required=False)
-def cli(ctx, parent_dir):
-    """Manage flamapy repositories and dependencies."""
-    ctx.ensure_object(dict)
-    ctx.obj['PARENT_DIR'] = parent_dir
-    # REPOS mapping should be provided in main CLI context
-    ctx.obj['REPOS'] = ctx.obj.get('REPOS', {})
-
-
-@cli.group()
-@click.pass_context
 def version(ctx):
     """Commands for managing Python dependencies."""
     ctx.ensure_object(dict)
+    ctx.obj['PARENT_DIR'] = ctx.obj.get('PARENT_DIR', os.curdir)
+    ctx.obj['REPOS'] = ctx.obj.get('REPOS', {})
 
 
 

--- a/flamapy_dev.py
+++ b/flamapy_dev.py
@@ -19,31 +19,21 @@ DEFAULT_PARENT_DIR = os.path.join(os.curdir)
 
 @click.group()
 @click.pass_context
-@click.argument('parent_dir', 
-                default=os.path.join(os.pardir), 
-                type=click.Path(exists=True, 
-                                file_okay=False, 
-                                dir_okay=True, 
-                                writable=True), 
-                required=False, 
-                metavar='[PARENT_DIR]',
+@click.option(
+    "--parent-dir",
+    "-d",
+    default=os.path.join(os.pardir),
+    type=click.Path(exists=True, file_okay=False, dir_okay=True, writable=True),
+    show_default=True,
+    help="Parent directory where operations should be performed.",
 )
 def cli(ctx, parent_dir):
     """Manage flamapy repositories and dependencies with various commands.
 
-    \b
-    PARENT_DIR:
-        - Optional positional argument. Specifies the parent directory where operations should be performed.
-        - If not provided, the default is the current working directory.
-
-    \b
     Examples:
-        - Run commands in the default parent directory:
-            $ flamapy-dev git clone
-        
-        - Run commands in a specific directory:
-            $ flamapy-dev /path/to/parent_dir git clone
-    """    
+        $ flamapy-dev git clone
+        $ flamapy-dev --parent-dir /path/to/parent_dir git clone
+    """
     ctx.ensure_object(dict)
     ctx.obj['REPOS'] = REPOS
     ctx.obj['PARENT_DIR'] = parent_dir

--- a/tests/test_repositories.py
+++ b/tests/test_repositories.py
@@ -23,7 +23,7 @@ def test_switch_develop_no_branch():
     run_mock.assert_not_called()
 
 
-def test_switch_main_or_master_prefers_main():
+def test_switch_main_prefers_main():
     runner = CliRunner()
     repos = {'repo1': 'url1'}
     obj = {'REPOS': repos, 'PARENT_DIR': '/tmp'}
@@ -40,14 +40,14 @@ def test_switch_main_or_master_prefers_main():
 
     with patch('commands.repositories.os.path.isdir', return_value=True), \
          patch('commands.repositories.subprocess.run', side_effect=side_effect) as run_mock:
-        result = runner.invoke(repositories.switch_main_or_master, obj=obj)
+        result = runner.invoke(repositories.switch_main, obj=obj)
 
     assert result.exit_code == 0
     switch_calls = [call.args[0] for call in run_mock.call_args_list if call.args and call.args[0][0:2] == ['git', 'switch']]
     assert switch_calls == [['git', 'switch', 'main']]
 
 
-def test_switch_main_or_master_uses_master():
+def test_switch_main_uses_master():
     runner = CliRunner()
     repos = {'repo1': 'url1'}
     obj = {'REPOS': repos, 'PARENT_DIR': '/tmp'}
@@ -64,7 +64,7 @@ def test_switch_main_or_master_uses_master():
 
     with patch('commands.repositories.os.path.isdir', return_value=True), \
          patch('commands.repositories.subprocess.run', side_effect=side_effect) as run_mock:
-        result = runner.invoke(repositories.switch_main_or_master, obj=obj)
+        result = runner.invoke(repositories.switch_main, obj=obj)
 
     assert result.exit_code == 0
     switch_calls = [call.args[0] for call in run_mock.call_args_list if call.args and call.args[0][0:2] == ['git', 'switch']]


### PR DESCRIPTION
## Summary
- add global `--parent-dir` option
- rename `switch_main_or_master` to `switch-main`
- simplify versions module interface
- adjust README examples and tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875163fde0c8322a884045ca078a921