### PR TITLE
Add git tag command

### DIFF
--- a/commands/repositories.py
+++ b/commands/repositories.py
@@ -109,9 +109,28 @@ def delete(ctx):
         else:
             click.echo(f"{repo_name} directory does not exist.")
 
+
+@git.command()
+@click.argument('tag')
+@click.pass_context
+def tag_repo(ctx, tag):
+    """Create and push a Git tag to all repositories."""
+    repos = ctx.obj['REPOS']
+    parent_dir = ctx.obj['PARENT_DIR']
+    for repo_name in repos.keys():
+        repo_dir = os.path.join(parent_dir, repo_name)
+        if os.path.isdir(os.path.join(repo_dir, '.git')):
+            click.echo(f"Tagging {repo_name} with {tag}...")
+            subprocess.run(['git', 'tag', tag], cwd=repo_dir, check=True)
+            click.echo(f"Pushing tag {tag} for {repo_name}...")
+            subprocess.run(['git', 'push', 'origin', tag], cwd=repo_dir, check=True)
+        else:
+            click.echo(f"{repo_name} does not exist.")
+
 git.add_command(clone)
 git.add_command(switch_develop)
 git.add_command(switch_main)
 git.add_command(pull)
 git.add_command(delete)
 git.add_command(status)
+git.add_command(tag_repo)

--- a/tests/test_repositories.py
+++ b/tests/test_repositories.py
@@ -117,3 +117,32 @@ def test_switch_develop_branch_missing_everywhere():
     assert result.exit_code == 0
     switch_calls = [call.args[0] for call in run_mock.call_args_list if call.args and call.args[0][0:2] == ['git', 'switch']]
     assert switch_calls == []
+
+
+def test_tag_repo_creates_and_pushes_tag():
+    runner = CliRunner()
+    repos = {'repo1': 'url1'}
+    obj = {'REPOS': repos, 'PARENT_DIR': '/tmp'}
+    with patch('commands.repositories.os.path.isdir', return_value=True), \
+         patch('commands.repositories.subprocess.run') as run_mock:
+        result = runner.invoke(repositories.tag_repo, ['v1.0'], obj=obj)
+
+    assert result.exit_code == 0
+    expected = [
+        ['git', 'tag', 'v1.0'],
+        ['git', 'push', 'origin', 'v1.0']
+    ]
+    calls = [c.args[0] for c in run_mock.call_args_list]
+    assert calls == expected
+
+
+def test_tag_repo_missing_repo():
+    runner = CliRunner()
+    repos = {'repo1': 'url1'}
+    obj = {'REPOS': repos, 'PARENT_DIR': '/tmp'}
+    with patch('commands.repositories.os.path.isdir', return_value=False), \
+         patch('commands.repositories.subprocess.run') as run_mock:
+        result = runner.invoke(repositories.tag_repo, ['v1.0'], obj=obj)
+
+    assert result.exit_code == 0
+    run_mock.assert_not_called()


### PR DESCRIPTION
## Summary
- add `tag_repo` command under the git command group to create and push tags to all repos
- test tagging logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68753d6952608322912ee23b70f7c396